### PR TITLE
Remove Quarto YAML file

### DIFF
--- a/workspaces/quarto_basic/_quarto.yml
+++ b/workspaces/quarto_basic/_quarto.yml
@@ -1,5 +1,0 @@
-project:
-  title: "quarto_basic"
-
-
-


### PR DESCRIPTION
This `_quarto.yml` file tells Quarto that this subdirectory is a Quarto project and nothing outside of that directory matters, while the `DESCRIPTION` file indicates this is an R package. There are two good options for moving forward:

- Remove the `_quarto.yml` file and treat this like an R package, work from the root directory of this project, and expect the output HTML in a temp directory.
- Keep the YAML file and treat this like a Quarto project, work from the `quarto_basic` subdirectory (i.e. open that as the Positron workspace), and expect the HTML in the same directory as the `.qmd`.

I think either one is a fine option.