### PR TITLE
Added Type to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,7 @@
 Package: qa.content.examples
 Title: Exampe R Content for Testing
 Version: 0.0.0.9000
+Type: TestAssets
 Description: Not really a package. This file is just to enable installing dependencies.
 Imports: 
     arrow,


### PR DESCRIPTION
Added a `Type` field to DESCRIPTION, so positron doesn't think it's an R package.

see https://github.com/posit-dev/positron/issues/2084#issuecomment-2338612346