### PR TITLE
add venv directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+**/.venv/*
 workspaces/quarto_basic/.quarto/*
 workspaces/quarto_basic/quarto_basic_files/*
 workspaces/quarto_basic/quarto_basic.html


### PR DESCRIPTION
- prevent accidentally committing `.venv` dirs
- relieve Git and the Git extension from trying to index `.venv` dirs