### PR TITLE
disable port hybrid mode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "positron.interpreters.automaticStartup": false,
     "positron.r.kernel.logLevel": "debug",
-    "python.languageServerLogLevel": "debug"
+    "python.languageServerLogLevel": "debug",
+    "remote.autoForwardPortsFallback": 0,
 }


### PR DESCRIPTION
After enabling browser tests in parallel, have noticed occasionally this popup during test execution. Disabling this setting to avoid it.
<img width="237" alt="Screenshot 2024-12-02 at 6 27 10 AM" src="https://github.com/user-attachments/assets/72e32eef-ef25-462d-bffd-beded829ff01">
