### PR TITLE
Fix notebook language info

### DIFF
--- a/workspaces/bitmap-notebook/bitmap-notebook.ipynb
+++ b/workspaces/bitmap-notebook/bitmap-notebook.ipynb
@@ -303,7 +303,7 @@
  ],
  "metadata": {
   "language_info": {
-   "name": "plaintext"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/workspaces/large_py_notebook/spotify.ipynb
+++ b/workspaces/large_py_notebook/spotify.ipynb
@@ -1633,7 +1633,7 @@
  ],
  "metadata": {
   "language_info": {
-   "name": "plaintext"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/workspaces/large_py_notebook/spotify_matplotlib.ipynb
+++ b/workspaces/large_py_notebook/spotify_matplotlib.ipynb
@@ -198,7 +198,7 @@
  ],
  "metadata": {
   "language_info": {
-   "name": "plaintext"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/workspaces/large_r_notebook/duplicate_plotly.ipynb
+++ b/workspaces/large_r_notebook/duplicate_plotly.ipynb
@@ -27,12 +27,6 @@
     }
   ],
   "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3",
-      "path": "/usr/local/share/jupyter/kernels/python3"
-    },
     "language_info": {
       "name": "r"
     }

--- a/workspaces/large_r_notebook/spotify.ipynb
+++ b/workspaces/large_r_notebook/spotify.ipynb
@@ -227,7 +227,7 @@
  ],
  "metadata": {
   "language_info": {
-   "name": "plaintext"
+   "name": "r"
   }
  },
  "nbformat": 4,

--- a/workspaces/matplotlib/interact.ipynb
+++ b/workspaces/matplotlib/interact.ipynb
@@ -61,7 +61,7 @@
  ],
  "metadata": {
   "language_info": {
-   "name": "r"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/workspaces/python-plots-widgets-notebook/plots-widgets-notebook.ipynb
+++ b/workspaces/python-plots-widgets-notebook/plots-widgets-notebook.ipynb
@@ -417,7 +417,7 @@
  ],
  "metadata": {
   "language_info": {
-   "name": "plaintext"
+   "name": "python"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR fixes the language info metadata in example notebooks. There might be a bug in Positron notebooks causing the incorrect language to be written to this field.

The incorrect languages are causing the wrong kernel to be started in a PR that reworks Positron notebook kernels: https://github.com/posit-dev/positron/actions/runs/12693575772, which this PR should fix.