### PR TITLE
Add new startup behavior option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "interpreters.automaticStartup": false,
+    "interpreters.startupBehavior": "manual",
     "positron.r.kernel.logLevel": "debug",
     "python.languageServerLogLevel": "debug",
     "remote.autoForwardPortsFallback": 0,


### PR DESCRIPTION
This repository uses the `interpreters.automaticStartup` feature, which is being deprecated in favor of an option with finer controls. This change adds the new option.

Supports https://github.com/posit-dev/positron/pull/6145.