### PR TITLE
Add ability to run workbench locally with specified positron version (ARM)

### DIFF
--- a/dockerfiles/wb-local/.gitignore
+++ b/dockerfiles/wb-local/.gitignore
@@ -1,0 +1,6 @@
+# Ignore environment variables file
+.env
+
+# Ignore any backup files that might be created
+*.bak
+*~

--- a/dockerfiles/wb-local/README.md
+++ b/dockerfiles/wb-local/README.md
@@ -1,0 +1,10 @@
+
+Terminal One
+./run.sh ubuntu24
+
+Terminal Two
+./connect.sh
+
+Example command:
+WB_URL=https://s3.amazonaws.com/rstudio-ide-build/server/jammy/arm64/rstudio-workbench-2025.11.0-daily-131.pro5-arm64.deb POSITRON_TAG=2025.10.0-88 GITHUB_TOKEN={your token} /tmp/install-workbench.sh
+

--- a/dockerfiles/wb-local/connect.sh
+++ b/dockerfiles/wb-local/connect.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# This script connects to the running test container
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  echo "Usage: ./connect.sh"
+  echo ""
+  echo "Connects to the running test container with an interactive bash shell"
+  exit 0
+fi
+
+# No command line arguments needed now
+
+# Load environment variables from .env file if it exists
+if [ -f .env ]; then
+  echo "Loading environment variables from .env file..."
+  export $(grep -v '^#' .env | xargs)
+fi
+
+# Check if the container is running
+if ! docker ps | grep -q "test"; then
+  echo "Error: test container is not running!"
+  echo "Please start it first with: ./run.sh [ubuntu24|rocky8]"
+  exit 1
+fi
+
+# Copy setup script to container
+
+if [ -f "./install-workbench.sh" ]; then
+  echo "Copying workbench setup script to container..."
+  docker cp ./install-workbench.sh test:/tmp/install-workbench.sh
+  docker exec test chmod +x /tmp/install-workbench.sh
+fi
+
+if [ -f "./download.sh" ]; then
+  echo "Copying download script to container..."
+  docker cp ./download.sh test:/tmp/download.sh
+  docker exec test chmod +x /tmp/download.sh
+fi
+
+# Connect to the container
+docker exec -it test /bin/bash

--- a/dockerfiles/wb-local/docker-compose.rocky8.yml
+++ b/dockerfiles/wb-local/docker-compose.rocky8.yml
@@ -1,0 +1,52 @@
+version: '3.8'
+
+services:
+  test:
+    image: ghcr.io/posit-dev/positron-rocky8-arm64:45
+    container_name: test
+    ports:
+      - "8080:8080"
+      - "5900:5900"
+      - "9323:9323"
+      - "8787:8787"
+    command: /bin/bash -c "while true; do sleep 3600; done"
+    tty: true
+    stdin_open: true
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - mynetwork
+    environment:
+      # Postgres configuration
+      - E2E_POSTGRES_USER=${E2E_POSTGRES_USER:-testuser}
+      - E2E_POSTGRES_PASSWORD=${E2E_POSTGRES_PASSWORD:-testpassword}
+      - E2E_POSTGRES_DB=${E2E_POSTGRES_DB:-testdb}
+      - Q_PASSWORD=${Q_PASSWORD:-testpassword}
+
+  postgres:
+    image: ghcr.io/posit-dev/positron-postgres-rocky8-arm64:45
+    container_name: postgres
+    ports:
+      - "5432:5432"
+    networks:
+      - mynetwork
+    environment:
+      - E2E_POSTGRES_USER=${E2E_POSTGRES_USER:-testuser}
+      - E2E_POSTGRES_PASSWORD=${E2E_POSTGRES_PASSWORD:-testpassword}
+      - E2E_POSTGRES_DB=${E2E_POSTGRES_DB:-testdb}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${E2E_POSTGRES_USER:-testuser} -d ${E2E_POSTGRES_DB:-testdb}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+networks:
+  mynetwork:
+    driver: bridge
+
+volumes:
+  postgres-data:

--- a/dockerfiles/wb-local/docker-compose.ubuntu24.yml
+++ b/dockerfiles/wb-local/docker-compose.ubuntu24.yml
@@ -1,0 +1,52 @@
+version: '3.8'
+
+services:
+  test:
+    image: ghcr.io/posit-dev/positron-ubuntu24-arm64:7
+    container_name: test
+    ports:
+      - "8080:8080"
+      - "5900:5900"
+      - "9323:9323"
+      - "8787:8787"
+    command: /bin/bash -c "while true; do sleep 3600; done"
+    tty: true
+    stdin_open: true
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - mynetwork
+    environment:
+      # Postgres configuration
+      - E2E_POSTGRES_USER=${E2E_POSTGRES_USER:-testuser}
+      - E2E_POSTGRES_PASSWORD=${E2E_POSTGRES_PASSWORD:-testpassword}
+      - E2E_POSTGRES_DB=${E2E_POSTGRES_DB:-testdb}
+      - Q_PASSWORD=${Q_PASSWORD:-testpassword}
+
+  postgres:
+    image: ghcr.io/posit-dev/positron-postgres-initialized-arm64:7
+    container_name: postgres
+    ports:
+      - "5432:5432"
+    networks:
+      - mynetwork
+    environment:
+      - E2E_POSTGRES_USER=${E2E_POSTGRES_USER:-testuser}
+      - E2E_POSTGRES_PASSWORD=${E2E_POSTGRES_PASSWORD:-testpassword}
+      - E2E_POSTGRES_DB=${E2E_POSTGRES_DB:-testdb}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${E2E_POSTGRES_USER:-testuser} -d ${E2E_POSTGRES_DB:-testdb}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+networks:
+  mynetwork:
+    driver: bridge
+
+volumes:
+  postgres-data:

--- a/dockerfiles/wb-local/download.sh
+++ b/dockerfiles/wb-local/download.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Config ---
+TOKEN="${GITHUB_TOKEN:-xyz}"               # set GITHUB_TOKEN in env, or replace xyz
+OWNER="posit-dev"
+REPO="positron-builds"
+# Optional: set TAG to force a specific release (e.g., TAG=2025.10.0-88)
+TAG="${TAG:-}"                             
+
+# Detect/override architecture suffix for asset name
+# (arm64 -> arm64, x86_64 -> x64)
+if [[ -n "${ARCH_SUFFIX:-}" ]]; then
+  ARCH="$ARCH_SUFFIX"
+else
+  case "$(uname -m)" in
+    aarch64|arm64) ARCH="arm64" ;;
+    x86_64|amd64)  ARCH="x64"   ;;
+    *) echo "Unsupported arch: $(uname -m)"; exit 1 ;;
+  esac
+fi
+
+api() {
+  curl -fsSL \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "$@"
+}
+
+# --- Get release JSON: latest or by tag ---
+if [[ -n "$TAG" ]]; then
+  echo "Fetching release by tag: $TAG"
+  rel_json="$(api "https://api.github.com/repos/$OWNER/$REPO/releases/tags/$TAG")"
+else
+  echo "Fetching latest release list (index 0)"
+  # releases API returns an array; pick the first (most recent)
+  releases="$(api "https://api.github.com/repos/$OWNER/$REPO/releases")"
+  rel_json="$(printf '%s' "$releases" | jq '.[0]')"
+  TAG="$(printf '%s' "$rel_json" | jq -r '.tag_name')"
+fi
+
+echo "Selected release tag: $TAG"
+
+# --- Pick the Workbench server tarball for our arch ---
+# Expected pattern: positron-workbench-linux-<arch>-<tag>.tar.gz
+asset_json="$(printf '%s' "$rel_json" | jq -r --arg arch "$ARCH" '
+  .assets[]
+  | select(.name
+      | test("^positron-workbench-linux-" + $arch + "-[0-9.\\-]+\\.tar\\.gz$"))
+')"
+
+if [[ -z "$asset_json" ]]; then
+  echo "No matching Workbench tarball found for arch '$ARCH' in release $TAG"
+  echo "Available assets:"
+  printf '%s' "$rel_json" | jq -r '.assets[].name'
+  exit 1
+fi
+
+name="$(printf '%s' "$asset_json" | jq -r '.name')"
+asset_api_url="$(printf '%s' "$asset_json" | jq -r '.url')"
+size="$(printf '%s' "$asset_json" | jq -r '.size')"
+
+echo "Downloading asset: $name (size: ${size} bytes) via Assets API..."
+curl -fL --retry 3 --retry-all-errors \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/octet-stream" \
+  -o "$name" \
+  "$asset_api_url"
+
+tar -xzf "$name" --strip-components=1

--- a/dockerfiles/wb-local/install-workbench.sh
+++ b/dockerfiles/wb-local/install-workbench.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Script parameters with defaults that can be overridden by environment variables
+WB_URL=${WB_URL:-"https://s3.amazonaws.com/rstudio-ide-build/server/jammy/arm64/rstudio-server-2025.11.0-daily-135-arm64.deb"}
+POSITRON_TAG=${POSITRON_TAG:-"2025.10.0-88"}
+GITHUB_TOKEN=${GITHUB_TOKEN:-"myToken"}
+ARCH_SUFFIX=${ARCH_SUFFIX:-"arm64"}
+
+# User configuration with defaults that can be overridden by environment variables
+Q_USER=${Q_USER:-"user1"}
+Q_UID=${Q_UID:-1100}
+Q_GID=${Q_GID:-1100}
+Q_GROUP=${Q_GROUP:-"user1g"}
+Q_PASSWORD=${Q_PASSWORD:-"testpassword"}
+
+# Log the configuration being used (but don't show the password)
+echo "Using configuration:"
+echo "  WB_URL: ${WB_URL}"
+echo "  POSITRON_TAG: ${POSITRON_TAG}"
+echo "  ARCH_SUFFIX: ${ARCH_SUFFIX}"
+echo "  Q_USER: ${Q_USER}"
+echo "  Q_UID: ${Q_UID}"
+echo "  Q_GID: ${Q_GID}"
+echo "  Q_GROUP: ${Q_GROUP}"
+echo "  Q_PASSWORD: [HIDDEN]"
+
+# Create the user
+echo "Creating user ${Q_USER}..."
+sudo groupadd -g ${Q_GID} ${Q_GROUP}
+sudo useradd --create-home --shell /bin/bash --home-dir /home/${Q_USER} -u ${Q_UID} -g ${Q_GROUP} ${Q_USER}
+echo "${Q_USER}":"${Q_PASSWORD}" | sudo chpasswd
+
+# Install required packages
+echo "Installing required packages..."
+sudo apt-get update
+sudo add-apt-repository -y universe
+sudo apt-get update
+sudo apt-get install -y acl jq
+
+# Configure RStudio
+echo "Configuring RStudio..."
+sudo mkdir -p /etc/rstudio
+echo "unprivileged=1" | sudo tee /etc/rstudio/launcher.local.conf > /dev/null
+
+# Download Workbench
+echo "Downloading Workbench..."
+curl ${WB_URL} --output workbench.deb
+
+# Install Workbench
+echo "Installing Workbench..."
+sudo apt install -y ./workbench.deb
+
+# Set access permissions
+echo "Setting access permissions..."
+sudo setfacl -m u:${Q_USER}:x /root
+sudo setfacl -R -m u:${Q_USER}:rx /root/.venv /root/.pyenv
+sudo setfacl -R -m d:u:${Q_USER}:rx /root/.venv /root/.pyenv
+
+# Update positron-server
+echo "Updating positron-server..."
+sudo rstudio-server stop
+cd /usr/lib/rstudio-server/bin/
+sudo mv positron-server positron-server-old
+sudo mkdir -p positron-server
+cd positron-server
+
+# Run download script
+echo "Running download script with TAG=${POSITRON_TAG}, ARCH_SUFFIX=${ARCH_SUFFIX}, GITHUB_TOKEN=${GITHUB_TOKEN}..."
+TAG=${POSITRON_TAG} ARCH_SUFFIX=${ARCH_SUFFIX} GITHUB_TOKEN=${GITHUB_TOKEN} /tmp/download.sh
+
+# Start RStudio server
+echo "Starting RStudio server..."
+sudo rstudio-server start
+
+echo "Installation complete."

--- a/dockerfiles/wb-local/run.sh
+++ b/dockerfiles/wb-local/run.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Default to ubuntu24 if no OS argument is provided
+OS_TYPE="ubuntu24"
+
+# Check for OS type argument
+if [ "$1" = "ubuntu24" ] || [ "$1" = "rocky8" ]; then
+  OS_TYPE="$1"
+  shift # Remove the OS argument from parameters
+elif [ "$1" != "-d" ] && [ "$1" != "--detach" ]; then
+  echo "Usage: $0 [ubuntu24|rocky8] [-d|--detach]"
+  echo "       Default is ubuntu24 if not specified"
+  echo ""
+fi
+
+# Set docker-compose file based on OS type
+COMPOSE_FILE="docker-compose.${OS_TYPE}.yml"
+
+# Load other environment variables from .env file if it exists
+if [ -f .env ]; then
+  echo "Loading environment variables from .env file..."
+  export $(grep -v '^#' .env | xargs)
+fi
+
+docker compose -f ${COMPOSE_FILE} up
+COMPOSE_STATUS=$?
+
+# If docker compose finished without error, copy scripts to container
+if [ $COMPOSE_STATUS -eq 0 ] && docker ps | grep -q "test"; then
+  if [ -f "./install-workbench.sh" ]; then
+      docker cp ./install-workbench.sh test:/tmp/install-workbench.sh
+      docker exec test chmod +x /tmp/install-workbench.sh
+  fi
+
+  if [ -f "./download.sh" ]; then
+      docker cp ./download.sh test:/tmp/download.sh
+      docker exec test chmod +x /tmp/download.sh
+  fi
+fi
+

--- a/dockerfiles/wb-local/stop-containers.sh
+++ b/dockerfiles/wb-local/stop-containers.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# stop-containers.sh - Script to stop and remove Docker containers
+
+# Default to ubuntu24 if no OS argument is provided
+OS_TYPE="ubuntu24"
+
+# Check for OS type argument
+if [ "$1" = "ubuntu24" ] || [ "$1" = "rocky8" ]; then
+  OS_TYPE="$1"
+else
+  echo "Usage: $0 [ubuntu24|rocky8]"
+  echo "       Default is ubuntu24 if not specified"
+  echo ""
+fi
+
+# Set docker-compose file based on OS type
+COMPOSE_FILE="docker-compose.${OS_TYPE}.yml"
+
+echo "Stopping and removing containers (${OS_TYPE})..."
+docker compose -f ${COMPOSE_FILE} down
+echo "Containers removed."
+
+# Optional: If you want to also remove volumes (uncomment the line below)
+# docker compose -f ${COMPOSE_FILE} down -v


### PR DESCRIPTION
Will do follow up PRs with better docs, helpful messaging in scripts, etc but just wanted to get v1 merged.

Basically allows you to bring a local workbench of a specified version with a Positron of a specified version (ARM).

This does not use SSL yet. You would go to http://localhost:8787/ and login as user1 with the password you put in .env:

Q_PASSWORD={desired user1 password}