### PR TITLE
workbench: require gh token, skip prompts for CI, log versions, log errors

### DIFF
--- a/dockerfiles/wb-local/README.md
+++ b/dockerfiles/wb-local/README.md
@@ -49,6 +49,12 @@ GITHUB_TOKEN=your_personal_access_token_here ./connect.sh
    2. Specific versions -  *enter custom URLs/tags when prompted*
    3. **Skip installation**  - *connect only for inspection/debugging*
 
+**For CI/Automated Usage:**
+```bash
+GITHUB_TOKEN=your_token ./connect.sh --ci
+```
+This bypasses all prompts and automatically installs the latest versions.
+
 ### Access Workbench
 
 Open <http://localhost:8787> and login:

--- a/dockerfiles/wb-local/install-workbench.sh
+++ b/dockerfiles/wb-local/install-workbench.sh
@@ -230,10 +230,10 @@ echo "Installation complete 🎉"
 
 # Extract Workbench version - just get the first word from "2025.11.0-daily+151.pro2 Workbench..."
 WB_VERSION=$(sudo rstudio-server version 2>/dev/null | head -1 | awk '{print $1}')
-
-echo "Workbench version:   ${WB_VERSION}"
 POSITRON_VERSION=$(cd /usr/lib/rstudio-server/bin/positron-server && grep '"positronVersion"' product.json 2>/dev/null | sed 's/.*"positronVersion": *"\([^"]*\)".*/\1/' || echo "Unknown")
+
 echo "Positron version:    ${POSITRON_VERSION}"
+echo "Workbench version:   ${WB_VERSION}"
 echo "Workbench URL:       http://localhost:8787"
 
 # Report any errors that occurred


### PR DESCRIPTION
Added a few little touches to the workbench install/connect scripts:
* fails fast if GH token is not provided
* ability to skip prompts and install latest with `--ci` flag
* at the end of install we log the versions
* if there are any errors, they are also logged after the script finishes for visibility
<img width="566" height="180" alt="Screenshot 2025-09-19 at 1 36 19 PM" src="https://github.com/user-attachments/assets/162bdfb6-dce5-4205-84eb-73abe616aee1" />
