### PR TITLE
jupyterhub: update license paths

### DIFF
--- a/dockerfiles/jupyter-local/connect.sh
+++ b/dockerfiles/jupyter-local/connect.sh
@@ -67,7 +67,6 @@ if [ -f "./positron.lic" ]; then
   echo "Copying license file to container..."
   LICENSE_ARCH=$(docker exec jupyter-test uname -m | sed 's/arm64/aarch64/')
   LICENSE_DEST="/opt/positron-server/resources/activation/linux/${LICENSE_ARCH}"
-  docker exec jupyter-test mkdir -p "${LICENSE_DEST}" >/dev/null 2>&1
   docker cp "./positron.lic" "jupyter-test:${LICENSE_DEST}/license.lic" >/dev/null 2>&1
 fi
 

--- a/dockerfiles/jupyter-local/connect.sh
+++ b/dockerfiles/jupyter-local/connect.sh
@@ -65,7 +65,10 @@ done
 # Copy license file if it exists (check for positron.lic in current directory)
 if [ -f "./positron.lic" ]; then
   echo "Copying license file to container..."
-  docker cp "./positron.lic" "jupyter-test:/opt/license.lic" >/dev/null 2>&1
+  LICENSE_ARCH=$(docker exec jupyter-test uname -m | sed 's/arm64/aarch64/')
+  LICENSE_DEST="/opt/positron-server/resources/activation/linux/${LICENSE_ARCH}"
+  docker exec jupyter-test mkdir -p "${LICENSE_DEST}" >/dev/null 2>&1
+  docker cp "./positron.lic" "jupyter-test:${LICENSE_DEST}/license.lic" >/dev/null 2>&1
 fi
 
 # Show current status

--- a/dockerfiles/jupyter-local/install-jupyter-positron.sh
+++ b/dockerfiles/jupyter-local/install-jupyter-positron.sh
@@ -152,12 +152,16 @@ else
     fi
 fi
 
-# No JupyterHub configuration needed - Positron uses default paths
-# (/opt/positron-server with license at /opt/license.lic)
+# Determine the license architecture directory name
+case "$(uname -m)" in
+    aarch64|arm64) LICENSE_ARCH="aarch64" ;;
+    *)             LICENSE_ARCH="x86_64" ;;
+esac
 
 # Check if license file exists
-if [ ! -f "/opt/license.lic" ]; then
-    echo "⚠️  WARNING: License file not found at /opt/license.lic"
+LICENSE_DEST="/opt/positron-server/resources/activation/linux/${LICENSE_ARCH}/license.lic"
+if [ ! -f "${LICENSE_DEST}" ]; then
+    echo "⚠️  WARNING: License file not found at ${LICENSE_DEST}"
     echo "   Positron will run in unlicensed mode with limitations."
 fi
 


### PR DESCRIPTION
follow up to https://github.com/posit-dev/positron/pull/13232 changing default path from `opt/license.lic` to `opt/positron-server/resources/activation/linux/{ARCH}/license.lic` 

note the license name no longer matters, we check for any *.lic in that location