### PR TITLE
astropy-testing: convert top docstring to # comments

### DIFF
--- a/workspaces/astropy-testing/plot_galactocentric_frame.py
+++ b/workspaces/astropy-testing/plot_galactocentric_frame.py
@@ -1,35 +1,33 @@
 # -*- coding: utf-8 -*-
-"""
-========================================================================
-Transforming positions and velocities to and from a Galactocentric frame
-========================================================================
-
-This document shows a few examples of how to use and customize the
-`~astropy.coordinates.Galactocentric` frame to transform Heliocentric sky
-positions, distance, proper motions, and radial velocities to a Galactocentric,
-Cartesian frame, and the same in reverse.
-
-The main configurable parameters of the `~astropy.coordinates.Galactocentric`
-frame control the position and velocity of the solar system barycenter within
-the Galaxy. These are specified by setting the ICRS coordinates of the
-Galactic center, the distance to the Galactic center (the sun-galactic center
-line is always assumed to be the x-axis of the Galactocentric frame), and the
-Cartesian 3-velocity of the sun in the Galactocentric frame. We'll first
-demonstrate how to customize these values, then show how to set the solar motion
-instead by inputting the proper motion of Sgr A*.
-
-Note that, for brevity, we may refer to the solar system barycenter as just "the
-sun" in the examples below.
-
--------------------
-
-*By: Adrian Price-Whelan*
-
-*License: BSD*
-
--------------------
-
-"""
+#
+# ========================================================================
+# Transforming positions and velocities to and from a Galactocentric frame
+# ========================================================================
+#
+# This document shows a few examples of how to use and customize the
+# `~astropy.coordinates.Galactocentric` frame to transform Heliocentric sky
+# positions, distance, proper motions, and radial velocities to a Galactocentric,
+# Cartesian frame, and the same in reverse.
+#
+# The main configurable parameters of the `~astropy.coordinates.Galactocentric`
+# frame control the position and velocity of the solar system barycenter within
+# the Galaxy. These are specified by setting the ICRS coordinates of the
+# Galactic center, the distance to the Galactic center (the sun-galactic center
+# line is always assumed to be the x-axis of the Galactocentric frame), and the
+# Cartesian 3-velocity of the sun in the Galactocentric frame. We'll first
+# demonstrate how to customize these values, then show how to set the solar
+# motion instead by inputting the proper motion of Sgr A*.
+#
+# Note that, for brevity, we may refer to the solar system barycenter as just
+# "the sun" in the examples below.
+#
+# -------------------
+#
+# *By: Adrian Price-Whelan*
+#
+# *License: BSD*
+#
+# -------------------
 
 ##############################################################################
 # Make `print` work the same in all versions of Python, set up numpy,


### PR DESCRIPTION
### Summary
Positron's welcome release-screenshot test splits this script on blank lines and runs each chunk in the console. The multi-line \`\"\"\"...\"\"\"\` docstring at the top contains blank lines, so the split broke it across cells: the kernel saw an unterminated string followed by bare-text "cells" that all cascaded into NameErrors and the second plot never rendered.

Converting the header to \`#\` comments preserves the upstream astropy-docs commentary but keeps the script splittable.

### QA Notes
- Verified locally with \`QA_REPO=mi/fix-galactic-frame-execution\` against the Positron welcome screenshot test — passes in 1.2m.