### PR TITLE
Add `r-session-hooks` workspace (`.Rprofile` + `DESCRIPTION`)

### DIFF
--- a/workspaces/r-session-hooks/.Rprofile
+++ b/workspaces/r-session-hooks/.Rprofile
@@ -18,8 +18,8 @@ setHook("positron.session_init", function(start_type) {
 	cat(paste0("[hook:init] project=", project, "\n"))
 
 	# Verify rstudioapi can trigger UI actions (navigateToFile)
-	rstudioapi::navigateToFile(".Rprofile")
-	cat("[hook:init] navigateToFile completed\n")
+	rstudioapi::navigateToFile("DESCRIPTION")
+	cat("[hook:init] navigateToFile DESCRIPTION completed\n")
 })
 
 setHook("positron.session_reconnect", function() {

--- a/workspaces/r-session-hooks/.Rprofile
+++ b/workspaces/r-session-hooks/.Rprofile
@@ -1,0 +1,40 @@
+cat("[.Rprofile] top-level code executed\n")
+
+setHook("positron.session_init", function(start_type) {
+	cat(paste0("[hook:init] start_type=", start_type, "\n"))
+
+	# Verify console width detection works (not the R default 80)
+	width <- getOption("width")
+	cat(paste0("[hook:init] options_width=", width, "\n"))
+
+	# Verify cli::console_width() returns actual width (common user pattern)
+	if (requireNamespace("cli", quietly = TRUE)) {
+		cli_width <- cli::console_width()
+		cat(paste0("[hook:init] cli_width=", cli_width, "\n"))
+	}
+
+	# Verify two-way rstudioapi communication works inside hook
+	project <- rstudioapi::getActiveProject()
+	cat(paste0("[hook:init] project=", project, "\n"))
+
+	# Verify rstudioapi can trigger UI actions (navigateToFile)
+	rstudioapi::navigateToFile(".Rprofile")
+	cat("[hook:init] navigateToFile completed\n")
+})
+
+setHook("positron.session_reconnect", function() {
+	cat("[hook:reconnect] fired\n")
+
+	# Verify width detection works on reconnect too
+	width <- getOption("width")
+	cat(paste0("[hook:reconnect] options_width=", width, "\n"))
+
+	if (requireNamespace("cli", quietly = TRUE)) {
+		cli_width <- cli::console_width()
+		cat(paste0("[hook:reconnect] cli_width=", cli_width, "\n"))
+	}
+
+	# Verify rstudioapi works on reconnect
+	project <- rstudioapi::getActiveProject()
+	cat(paste0("[hook:reconnect] project=", project, "\n"))
+})

--- a/workspaces/r-session-hooks/.Rprofile
+++ b/workspaces/r-session-hooks/.Rprofile
@@ -14,7 +14,7 @@ setHook("positron.session_init", function(start_type) {
 	}
 
 	# Verify two-way rstudioapi communication works inside hook
-	project <- rstudioapi::getActiveProject()
+	project <- basename(rstudioapi::getActiveProject())
 	cat(paste0("[hook:init] project=", project, "\n"))
 
 	# Verify rstudioapi can trigger UI actions (navigateToFile)

--- a/workspaces/r-session-hooks/.Rprofile
+++ b/workspaces/r-session-hooks/.Rprofile
@@ -35,6 +35,6 @@ setHook("positron.session_reconnect", function() {
 	}
 
 	# Verify rstudioapi works on reconnect
-	project <- rstudioapi::getActiveProject()
+	project <- basename(rstudioapi::getActiveProject())
 	cat(paste0("[hook:reconnect] project=", project, "\n"))
 })

--- a/workspaces/r-session-hooks/DESCRIPTION
+++ b/workspaces/r-session-hooks/DESCRIPTION
@@ -1,0 +1,5 @@
+Package: rsessionhooks
+Title: Test Workspace for R Session Hooks
+Version: 0.0.1
+Description: Dummy package used by E2E tests to verify rstudioapi::navigateToFile("DESCRIPTION") works inside session hooks.
+License: MIT


### PR DESCRIPTION
Adds `.Rprofile` with `positron.session_init` and `positron.session_reconnect` hooks for E2E testing (posit-dev/positron#12802).

### Background

`.Rprofile` is an R startup file executed automatically when a session starts. Users use it to configure options, load packages, and customize IDE behavior; this can be of very high-value for R users transitioning to Positron.

### What this adds

A dedicated workspace with an `.Rprofile` that exercises session hooks and a `DESCRIPTION` file used as a `navigateToFile()` target. The profile validates:

- Hook firing with correct `start_type` across new, restart, and reconnect flows
- Console width propagation (`options("width")` and `cli::console_width()`)
- Two-way `rstudioapi` communication inside hooks (`getActiveProject()`, `navigateToFile("DESCRIPTION")`)

### QA Hot Points 🌶️

- E2E tests should verify expected console output, correct hook firing behavior, and that `DESCRIPTION` opens via `rstudioapi::navigateToFile()`.
- This `.Rprofile` was intentionally added in a dedicated subfolder rather than the global `qa-example-content` root to avoid affecting unrelated QA workflows and startup behavior. 
  - Since `.Rprofile` files are automatically executed at R session startup, keeping this isolated ensures the hook-based lifecycle testing only applies to scenarios that explicitly opt into it.