### PR TITLE
Pin html tools due to breaking change with shiny

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,4 @@ SQLAlchemy
 psycopg2-binary
 ipykernel
 astropy
+htmltools<0.7


### PR DESCRIPTION
Pinned `htmltools<0.7` in `qa-example-content/requirements.txt` to unblock the Windows Shiny e2e test after htmltools 0.7.0 tightened the `Tagifiable.tagify()` contract.

Due to: [posit-dev/py-htmltools#114](https://github.com/posit-dev/py-htmltools/issues/114) — that tracks the four downstream Posit PRs (py-shiny, shinychat, chatlas, brand-yml) shipping releases compatible with the new contract.

