### PR TITLE
Add workspace fixtures for venv auto-creation e2e tests

### DIFF
--- a/workspaces/python-venv-creation/with-existing-venv/.venv/pyvenv.cfg
+++ b/workspaces/python-venv-creation/with-existing-venv/.venv/pyvenv.cfg
@@ -1,0 +1,3 @@
+home = /usr/bin
+include-system-site-packages = false
+version = 3.12.0

--- a/workspaces/python-venv-creation/with-existing-venv/main.py
+++ b/workspaces/python-venv-creation/with-existing-venv/main.py
@@ -1,0 +1,1 @@
+import requests

--- a/workspaces/python-venv-creation/with-existing-venv/requirements.txt
+++ b/workspaces/python-venv-creation/with-existing-venv/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/workspaces/python-venv-creation/with-requirements/main.py
+++ b/workspaces/python-venv-creation/with-requirements/main.py
@@ -1,0 +1,1 @@
+import requests

--- a/workspaces/python-venv-creation/with-requirements/requirements.txt
+++ b/workspaces/python-venv-creation/with-requirements/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
Two test workspaces for Positron's Python venv auto-creation feature (posit-dev/positron#13437):

- `with-requirements/` — has `requirements.txt`, no `.venv` (triggers notification)
- `with-existing-venv/` — has `requirements.txt` + `.venv/` (suppresses notification)