### PR TITLE
Add nycflights SQLite connections workspace script

### DIFF
--- a/workspaces/nycflights-sqlite-r/nycflights-sqlite.r
+++ b/workspaces/nycflights-sqlite-r/nycflights-sqlite.r
@@ -1,0 +1,6 @@
+library(connections)
+library(DBI)
+library(RSQLite)
+
+db_path <- file.path(getwd(), "db", "nycflights13.sqlite")
+con <- connection_open(SQLite(), db_path)


### PR DESCRIPTION
### Summary
Adds `workspaces/nycflights-sqlite-r/nycflights-sqlite.r` for use by the Positron e2e release screenshot test (`connections-pane-schema-explorer.png`).
- Follows the same pattern as `workspaces/chinook-db-r/chinook-sqlite.r`
- The SQLite DB is built at test time; this file holds the 6-line connection-open script

### QA Notes
Companion to posit-dev/positron branch `mi/more-release-screenshots`.