### PR TITLE
Update nycflights SQLite script to match original sqlite.R

### DIFF
--- a/workspaces/nycflights-sqlite-r/nycflights-sqlite.r
+++ b/workspaces/nycflights-sqlite-r/nycflights-sqlite.r
@@ -1,6 +1,9 @@
-library(connections)
-library(DBI)
-library(RSQLite)
+path <- dbplyr::nycflights13_sqlite(path = "db/")
 
-db_path <- file.path(getwd(), "db", "nycflights13.sqlite")
-con <- connection_open(SQLite(), db_path)
+library(DBI)
+con <- dbConnect(
+  RSQLite::SQLite(),
+  dbname = "db/nycflights13.sqlite",
+  bigint = "integer64"
+)
+connections::connection_view(con)


### PR DESCRIPTION
### Summary
Updates `workspaces/nycflights-sqlite-r/nycflights-sqlite.r` to match the original `sqlite.R` reference screenshot.
- Switches to `dbplyr::nycflights13_sqlite() + dbConnect + connections::connection_view` pattern
- `nycflights13_sqlite()` exits early when the DB file already exists (cache=TRUE default), so the CI test pre-builds the schema with CREATE TABLE and this call is a no-op — no `nycflights13` package needed
- Adds `bigint = "integer64"` to match original

### QA Notes
Companion to posit-dev/positron branch `mi/more-release-screenshots`.