### PR TITLE
Drop dbplyr::nycflights13_sqlite — nycflights13 not in CI

### DIFF
--- a/workspaces/nycflights-sqlite-r/nycflights-sqlite.r
+++ b/workspaces/nycflights-sqlite-r/nycflights-sqlite.r
@@ -1,5 +1,3 @@
-path <- dbplyr::nycflights13_sqlite(path = "db/")
-
 library(DBI)
 con <- dbConnect(
   RSQLite::SQLite(),


### PR DESCRIPTION
### Summary
`nycflights13_sqlite()` always loads the `nycflights13` package even when the DB file already exists — it doesn't short-circuit on cache hit. Since `nycflights13` isn't installed in CI, drop that line and connect directly via `dbConnect` against the pre-built DB.

### QA Notes
Companion to posit-dev/positron branch `mi/more-release-screenshots`.