### PR TITLE
Restore full nycflights sqlite script matching reference

### DIFF
--- a/workspaces/nycflights-sqlite-r/nycflights-sqlite.r
+++ b/workspaces/nycflights-sqlite-r/nycflights-sqlite.r
@@ -1,3 +1,5 @@
+path <- dbplyr::nycflights13_sqlite(path = "db/")
+
 library(DBI)
 con <- dbConnect(
   RSQLite::SQLite(),


### PR DESCRIPTION
### Summary
Restores `workspaces/nycflights-sqlite-r/nycflights-sqlite.r` to the full original script matching the reference screenshot. The test's `executeCode` step now runs `dbplyr::nycflights13_sqlite` to build the DB, so both the test setup and editor display use identical code.

### QA Notes
Companion to posit-dev/positron branch `mi/more-release-screenshots`.