### PR TITLE
Add nycflights13 and dbplyr to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,4 +37,6 @@ Imports:
     viridis,
     RPostgres,
     DBI,
-    connections
+    connections,
+    nycflights13,
+    dbplyr


### PR DESCRIPTION
### Summary
Adds `nycflights13` and `dbplyr` to `DESCRIPTION` so `pak::local_install_dev_deps()` installs them in CI. Required by `workspaces/nycflights-sqlite-r/nycflights-sqlite.r` which calls `dbplyr::nycflights13_sqlite()` for the connections-pane-schema-explorer release screenshot test.

### QA Notes
Companion to posit-dev/positron branch `mi/more-release-screenshots`.