### PR TITLE
arm-local: add e2e-server support and improved shell UX

### DIFF
--- a/dockerfiles/arm-local/README.md
+++ b/dockerfiles/arm-local/README.md
@@ -41,17 +41,10 @@ Or for Rocky 8: `npm run arm:start:rocky`
 npm run arm:connect
 ```
 
-You'll see a menu. Options depend on whether the environment has been set up:
+You'll see a menu with two options regardless of state:
 
-**First run (not yet set up):**
-1. **Setup environment** - Clones repo, installs dependencies, and compiles (prompts for branch)
-2. **Skip to shell**
-
-**Subsequent runs (already set up):**
-1. **Update environment** - Pulls latest changes and reinstalls dependencies (prompts for branch)
-2. **Update + start e2e server** - Pulls latest, reinstalls, then starts the Positron server on `:8080` for `e2e-server` browser tests
-3. **Start e2e server** - Starts the Positron server on `:8080` without updating (use when code hasn't changed)
-4. **Skip to shell**
+1. **Setup / Update environment** - Clones (first run) or pulls latest and reinstalls (subsequent runs). Prompts for branch.
+2. **Skip to shell** - Jump straight to the shell. Use shell commands (see below) to start the server, view reports, etc.
 
 After setup completes, you're ready to run tests:
 

--- a/dockerfiles/arm-local/README.md
+++ b/dockerfiles/arm-local/README.md
@@ -18,7 +18,7 @@ Create a `license.txt` file in this directory with the Positron Workbench Licens
 ### 3. Docker Login
 
 ```bash
-docker login ghcr.io -u <your_github_username>
+docker login ghcr.io -u <your_github_username> 
 ```
 
 Use a GitHub Personal Access Token with `read:packages` scope as your password.
@@ -41,15 +41,26 @@ Or for Rocky 8: `npm run arm:start:rocky`
 npm run arm:connect
 ```
 
-You'll see a menu:
-1. **Setup test environment** - Clones repo and installs dependencies (prompts for branch)
-2. **Skip to shell** - For reconnecting or manual setup
+You'll see a menu. Options depend on whether the environment has been set up:
+
+**First run (not yet set up):**
+1. **Setup environment** - Clones repo, installs dependencies, and compiles (prompts for branch)
+2. **Skip to shell**
+
+**Subsequent runs (already set up):**
+1. **Update environment** - Pulls latest changes and reinstalls dependencies (prompts for branch)
+2. **Update + start e2e server** - Pulls latest, reinstalls, then starts the Positron server on `:8080` for `e2e-server` browser tests
+3. **Start e2e server** - Starts the Positron server on `:8080` without updating (use when code hasn't changed)
+4. **Skip to shell**
 
 After setup completes, you're ready to run tests:
 
 ```bash
+# Electron tests (run inside the container)
 npx playwright test --project e2e-electron --workers 2 --grep @:connections
-npx playwright test --project e2e-browser --workers 2 --grep @:data-explorer
+
+# Browser tests against the e2e server (can be run from your local Positron repo)
+npx playwright test --project e2e-server --workers 2 --grep @:web
 ```
 
 ## All npm Scripts

--- a/dockerfiles/arm-local/connect.sh
+++ b/dockerfiles/arm-local/connect.sh
@@ -116,33 +116,14 @@ else
         echo "Display: $DISPLAY_STATUS"
     fi
 
-    start_server() {
-        echo ""
-        echo "Starting Positron e2e server on port 8080..."
-        cd /__w/positron/positron
-        ./scripts/code-server.sh --no-launch --host 0.0.0.0 --connection-token dev-token --port 8080 \
-            --user-data-dir $HOME/.positron-e2e-test \
-            --disable-telemetry --disable-experiments --skip-welcome --skip-release-notes \
-            --no-cached-data --disable-updates --use-inmemory-secretstorage \
-            --disable-workspace-trust > /tmp/e2e-server.log 2>&1 &
-        sleep 3
-        if curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/?tkn=dev-token | grep -q "30[12]"; then
-            echo "Server is up -> http://localhost:8080/?tkn=dev-token"
-        else
-            echo "Server starting... (tail /tmp/e2e-server.log to check)"
-        fi
-    }
-
     echo ""
     echo "=== Options ==="
     if [ "$SETUP_DONE" = true ]; then
-        echo "1) Update environment            [git pull + reinstall]"
-        echo "2) Update + start e2e server     [git pull + reinstall + start server on :8080]"
-        echo "3) Start e2e server              [start server on :8080, no update]"
-        echo "4) Skip to shell"
+        echo "1) Update environment   [git pull + reinstall]"
+        echo "2) Skip to shell"
         echo ""
-        read -p "Choice [1-4, default=4]: " choice
-        choice=${choice:-4}
+        read -p "Choice [1-2, default=2]: " choice
+        choice=${choice:-2}
     else
         echo "1) Setup environment   [clone + install]"
         echo "2) Skip to shell"
@@ -159,20 +140,6 @@ else
         /tmp/setup-test-env.sh "$branch"
         ;;
       2)
-        if [ "$SETUP_DONE" = true ]; then
-            echo ""
-            read -p "Branch [default=main]: " branch
-            branch=${branch:-main}
-            /tmp/setup-test-env.sh "$branch"
-            start_server
-        fi
-        ;;
-      3)
-        if [ "$SETUP_DONE" = true ]; then
-            start_server
-        fi
-        ;;
-      4)
         ;;
       *)
         echo "Invalid choice."

--- a/dockerfiles/arm-local/connect.sh
+++ b/dockerfiles/arm-local/connect.sh
@@ -83,11 +83,25 @@ else
         SETUP_DONE=false
     fi
 
+    # Ensure Xvfb is running (required for electron tests)
+    if ! pgrep -x Xvfb >/dev/null 2>&1; then
+        /usr/bin/Xvfb :10 -ac -screen 0 2560x1440x24 > /tmp/Xvfb.out 2>&1 &
+        sleep 1
+    fi
+    export DISPLAY=:10
+
     # Check Xvfb
     if pgrep -x Xvfb >/dev/null 2>&1; then
         DISPLAY_STATUS="running"
     else
         DISPLAY_STATUS="not running"
+    fi
+
+    # Check e2e server
+    if ss -tlnp 2>/dev/null | grep -q ":8080" || netstat -tlnp 2>/dev/null | grep -q ":8080"; then
+        SERVER_STATUS="running  → http://localhost:8080/?tkn=dev-token"
+    else
+        SERVER_STATUS="not running"
     fi
 
     echo ""
@@ -96,25 +110,43 @@ else
         echo "Branch:  $BRANCH"
         echo "Commit:  $COMMIT"
         echo "Display: $DISPLAY_STATUS"
+        echo "Server:  $SERVER_STATUS"
     else
         echo "Setup:   Not complete"
         echo "Display: $DISPLAY_STATUS"
     fi
 
+    start_server() {
+        echo ""
+        echo "Starting Positron e2e server on port 8080..."
+        cd /__w/positron/positron
+        ./scripts/code-server.sh --no-launch --host 0.0.0.0 --connection-token dev-token --port 8080 \
+            --user-data-dir $HOME/.positron-e2e-test \
+            --disable-telemetry --disable-experiments --skip-welcome --skip-release-notes \
+            --no-cached-data --disable-updates --use-inmemory-secretstorage \
+            --disable-workspace-trust > /tmp/e2e-server.log 2>&1 &
+        sleep 3
+        if curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/?tkn=dev-token | grep -q "30[12]"; then
+            echo "Server is up -> http://localhost:8080/?tkn=dev-token"
+        else
+            echo "Server starting... (tail /tmp/e2e-server.log to check)"
+        fi
+    }
+
     echo ""
     echo "=== Options ==="
     if [ "$SETUP_DONE" = true ]; then
-        echo "1) Update environment  [git pull + reinstall]"
+        echo "1) Update environment            [git pull + reinstall]"
+        echo "2) Update + start e2e server     [git pull + reinstall + start server on :8080]"
+        echo "3) Start e2e server              [start server on :8080, no update]"
+        echo "4) Skip to shell"
+        echo ""
+        read -p "Choice [1-4, default=4]: " choice
+        choice=${choice:-4}
     else
         echo "1) Setup environment   [clone + install]"
-    fi
-    echo "2) Skip to shell"
-    echo ""
-
-    if [ "$SETUP_DONE" = true ]; then
-        read -p "Choice [1-2, default=2]: " choice
-        choice=${choice:-2}
-    else
+        echo "2) Skip to shell"
+        echo ""
         read -p "Choice [1-2, default=1]: " choice
         choice=${choice:-1}
     fi
@@ -127,6 +159,20 @@ else
         /tmp/setup-test-env.sh "$branch"
         ;;
       2)
+        if [ "$SETUP_DONE" = true ]; then
+            echo ""
+            read -p "Branch [default=main]: " branch
+            branch=${branch:-main}
+            /tmp/setup-test-env.sh "$branch"
+            start_server
+        fi
+        ;;
+      3)
+        if [ "$SETUP_DONE" = true ]; then
+            start_server
+        fi
+        ;;
+      4)
         ;;
       *)
         echo "Invalid choice."
@@ -137,13 +183,21 @@ else
     echo ""
     if [ -d "/__w/positron/positron/.git" ]; then
         echo "=== Quick Reference ==="
-        echo "Example test commands:"
-        echo "  npx playwright test --project e2e-electron --workers 2 --grep @:connections"
-        echo "  npx playwright test --project e2e-browser --workers 2 --grep @:data-explorer"
+        echo "Test commands:"
+        echo "  run-tests --project e2e-electron --workers 2 --grep @:connections"
+        echo "  run-tests --project e2e-server   --workers 2 --grep @:web"
         echo ""
         echo "Other commands:"
-        echo "  /tmp/start-vnc.sh    - Start VNC server"
-        echo "  /tmp/ssh-install.sh  - Install SSH server"
+        echo "  start-server   - Start e2e server on :8080"
+        echo "  start-vnc      - Watch tests run visually (connect to localhost:5900)"
+        echo "  show-report    - Serve test report at http://localhost:9323"
+        echo "  install-ssh    - Install SSH server (for Remote SSH editor access)"
+        echo "  status         - Reprint branch, display, and server status"
+        echo "  commands       - Reprint this list"
+        echo ""
+        echo "Logs:"
+        echo "  tail /tmp/e2e-server.log  - e2e server logs"
+        echo "  tail /tmp/Xvfb.out        - display server logs"
         echo ""
         cd /__w/positron/positron
     else

--- a/dockerfiles/arm-local/docker-compose.ubuntu24.yml
+++ b/dockerfiles/arm-local/docker-compose.ubuntu24.yml
@@ -10,6 +10,8 @@ services:
       - "5900:5900"
       - "9323:9323"
       - "3456:22"
+    volumes:
+      - /private/tmp/positron-e2e:/tmp/positron-e2e
     command: /bin/bash -c "while true; do sleep 3600; done"
     tty: true
     stdin_open: true

--- a/dockerfiles/arm-local/setup-test-env.sh
+++ b/dockerfiles/arm-local/setup-test-env.sh
@@ -207,7 +207,6 @@ EOF
 cat > /usr/local/bin/run-tests <<EOF
 #!/bin/bash
 cd $REPO_DIR && npx playwright test "\$@"
-npx playwright show-report --host 0.0.0.0
 EOF
 chmod +x /usr/local/bin/run-tests
 

--- a/dockerfiles/arm-local/setup-test-env.sh
+++ b/dockerfiles/arm-local/setup-test-env.sh
@@ -203,12 +203,94 @@ export PWTEST_BLOB_DO_NOT_REMOVE="1"
 cd $REPO_DIR
 EOF
 
-# Add a helper script to run tests
+# Add helper scripts and aliases
 cat > /usr/local/bin/run-tests <<EOF
 #!/bin/bash
 cd $REPO_DIR && npx playwright test "\$@"
+npx playwright show-report --host 0.0.0.0
 EOF
 chmod +x /usr/local/bin/run-tests
+
+cat > /usr/local/bin/start-server <<EOF
+#!/bin/bash
+echo "Starting Positron e2e server on port 8080..."
+cd $REPO_DIR
+./scripts/e2e-start-server.sh 8080 dev-token \$HOME/.positron-e2e-test 0.0.0.0 > /tmp/e2e-server.log 2>&1 &
+sleep 2
+if ss -tlnp 2>/dev/null | grep -q ":8080" || netstat -tlnp 2>/dev/null | grep -q ":8080"; then
+    echo "Server is up -> http://localhost:8080/?tkn=dev-token"
+else
+    echo "Server starting... (tail /tmp/e2e-server.log to check)"
+fi
+EOF
+chmod +x /usr/local/bin/start-server
+
+cat > /usr/local/bin/start-vnc <<EOF
+#!/bin/bash
+/tmp/start-vnc.sh
+EOF
+chmod +x /usr/local/bin/start-vnc
+
+cat > /usr/local/bin/install-ssh <<EOF
+#!/bin/bash
+/tmp/ssh-install.sh
+EOF
+chmod +x /usr/local/bin/install-ssh
+
+cat > /usr/local/bin/show-report <<EOF
+#!/bin/bash
+echo "Opening test report at http://localhost:9323 ..."
+cd $REPO_DIR && npx playwright show-report --host 0.0.0.0
+EOF
+chmod +x /usr/local/bin/show-report
+
+cat > /usr/local/bin/status <<EOF
+#!/bin/bash
+echo ""
+echo "=== Status ==="
+if [ -d "/__w/positron/positron/.git" ]; then
+    BRANCH=\$(cd /__w/positron/positron && git branch --show-current 2>/dev/null)
+    COMMIT=\$(cd /__w/positron/positron && git log -1 --format="%h %s" 2>/dev/null)
+    echo "Branch:  \$BRANCH"
+    echo "Commit:  \$COMMIT"
+else
+    echo "Setup:   Not complete"
+fi
+if pgrep -x Xvfb >/dev/null 2>&1; then
+    echo "Display: running"
+else
+    echo "Display: not running"
+fi
+if curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/?tkn=dev-token 2>/dev/null | grep -q "30[12]"; then
+    echo "Server:  running -> http://localhost:8080/?tkn=dev-token"
+else
+    echo "Server:  not running"
+fi
+echo ""
+EOF
+chmod +x /usr/local/bin/status
+
+cat > /usr/local/bin/commands <<EOF
+#!/bin/bash
+echo ""
+echo "=== Test Commands ==="
+echo "  run-tests --project e2e-electron --workers 2 --grep @:connections"
+echo "  run-tests --project e2e-server   --workers 2 --grep @:web"
+echo ""
+echo "=== Other Commands ==="
+echo "  start-server   - Start e2e server on :8080"
+echo "  start-vnc      - Watch tests run visually (connect to localhost:5900)"
+echo "  show-report    - Serve test report at http://localhost:9323"
+echo "  install-ssh    - Install SSH server (for Remote SSH editor access)"
+echo "  status         - Show branch, display, and server status"
+echo "  commands       - Show this list"
+echo ""
+echo "=== Logs ==="
+echo "  tail /tmp/e2e-server.log  - e2e server logs"
+echo "  tail /tmp/Xvfb.out        - display server logs"
+echo ""
+EOF
+chmod +x /usr/local/bin/commands
 
 echo ""
 echo "===== Test Environment Setup Complete ====="
@@ -224,14 +306,5 @@ if [ ${#ERRORS[@]} -gt 0 ]; then
     echo "Setup may not be fully functional. Check logs above for details."
 fi
 
-echo ""
-echo "Ready to run tests. Example commands:"
-echo "  npx playwright test --project e2e-electron --workers 2 --grep @:connections"
-echo "  npx playwright test --project e2e-browser --workers 2 --grep @:data-explorer"
-echo ""
-echo "Other useful commands:"
-echo "  /tmp/start-vnc.sh                        - Start VNC server (connect to localhost:5900)"
-echo "  npx playwright show-report --host 0.0.0.0 - View test report (localhost:9323)"
-echo ""
 echo "NOTE: If you open a new terminal/shell, run: source ~/.bashrc"
 echo ""


### PR DESCRIPTION
### Summary
Enables \`e2e-server\` browser tests to be run from the Positron UI against a Positron server running in the arm-local container, and improves the day-to-day shell experience.
- Bind-mount \`/private/tmp/positron-e2e\` into the container so test workspace paths from the Mac test runner are accessible to the Positron server
- Auto-start Xvfb on every \`arm:connect\` so electron tests work without manual setup
- Add convenience shell commands: \`start-server\`, \`show-report\`, \`start-vnc\`, \`install-ssh\`, \`status\`, \`commands\`
- Simplify connect menu to two options — server start moved to \`start-server\` shell command
- Update README with new menu and shell commands

### QA Notes
Requires companion PR in posit-dev/positron for the test runner path configuration: https://github.com/posit-dev/positron/pull/14030