### PR TITLE
arm-local: fix trace viewer service worker error

### DIFF
--- a/dockerfiles/arm-local/setup-test-env.sh
+++ b/dockerfiles/arm-local/setup-test-env.sh
@@ -238,8 +238,9 @@ chmod +x /usr/local/bin/install-ssh
 
 cat > /usr/local/bin/show-report <<EOF
 #!/bin/bash
-echo "Opening test report at http://localhost:9323 ..."
-cd $REPO_DIR && npx playwright show-report --host 0.0.0.0
+echo "Serving test report at http://localhost:9323"
+echo "(Use localhost, not 0.0.0.0 — trace viewer requires localhost for service workers)"
+cd $REPO_DIR && npx playwright show-report --host 0.0.0.0 2>&1 | grep -v "Serving HTML report"
 EOF
 chmod +x /usr/local/bin/show-report
 


### PR DESCRIPTION
### Summary
Fix "Service workers are not supported" error when viewing Playwright trace reports from the container.

- Suppress Playwright's default URL output (which shows `0.0.0.0`)
- Show only the `localhost` URL so trace viewer service workers work
- Server still binds to `0.0.0.0` for Docker port forwarding

### QA Notes
Rebuild container, run tests, run `show-report`, confirm trace viewer loads at `localhost:9323`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)