### PR TITLE
Add largeParquet to gitignore

### DIFF
--- a/workspaces/r_testing/.gitignore
+++ b/workspaces/r_testing/.gitignore
@@ -1,1 +1,2 @@
 .Rproj.user
+/data-files/largeParquet.parquet


### PR DESCRIPTION
Positron's very-large-data-frame.test.ts downloads data-files/largeParquet.parquet from S3 at runtime into the shared e2e workspace (this repo). The file is untracked and not ignored.

Because all 3 e2e workers share one workspace directory, a concurrent test's teardown (git clean -fd) deletes this untracked file mid-run. The result is an intermittent IOError: Failed to open local file '.../largeParquet.parquet' ... No such file or directory in the data-explorer performance tests — the fixture downloads fine, then gets wiped before the next test reads it.

Adding it to .gitignore fixes this: git clean -fd (no -x) skips ignored files, so the download survives.