### PR TITLE
Allow for installing workbench stable locally too

### DIFF
--- a/dockerfiles/wb-local/README.md
+++ b/dockerfiles/wb-local/README.md
@@ -116,6 +116,12 @@ GITHUB_TOKEN=your_token ./connect.sh --ci
 This bypasses all prompts and automatically installs the latest versions. Add
 `--credentials=<databricks|snowflake|azure>` to configure a data source.
 
+Use `--ci-stable` instead of `--ci` to install the latest Positron with the
+released (stable) Workbench:
+```bash
+GITHUB_TOKEN=your_token ./connect.sh --ci-stable
+```
+
 ## Cleanup
 
 1. Terminal 2: `exit`

--- a/dockerfiles/wb-local/connect.sh
+++ b/dockerfiles/wb-local/connect.sh
@@ -7,6 +7,7 @@ export MSYS_NO_PATHCONV=1
 
 # Parse command line arguments
 CI_MODE=false
+CI_STABLE_MODE=false
 CREDENTIALS=""
 while [ $# -gt 0 ]; do
   case $1 in
@@ -16,13 +17,18 @@ while [ $# -gt 0 ]; do
       echo "Connects to the running test container with an interactive bash shell"
       echo ""
       echo "OPTIONS:"
-      echo "  --ci                      CI mode: skip all prompts and use defaults (requires GITHUB_TOKEN env var)"
+      echo "  --ci                      CI mode: skip all prompts and use latest versions (requires GITHUB_TOKEN env var)"
+      echo "  --ci-stable               CI mode: skip all prompts, latest Positron + released Workbench (requires GITHUB_TOKEN env var)"
       echo "  --credentials=<type>      Configure one credential type: databricks, snowflake, or azure"
       echo "  -h, --help                Show this help message"
       exit 0
       ;;
     --ci)
       CI_MODE=true
+      shift
+      ;;
+    --ci-stable)
+      CI_STABLE_MODE=true
       shift
       ;;
     --credentials=*)
@@ -115,8 +121,14 @@ fi
 echo ""
 
 # Connect to the container and run install script
-if [ "$CI_MODE" = true ]; then
-  echo "Running in CI mode - using latest versions without prompts..."
+if [ "$CI_MODE" = true ] || [ "$CI_STABLE_MODE" = true ]; then
+  if [ "$CI_STABLE_MODE" = true ]; then
+    CI_INSTALL_FLAG="--ci-stable"
+    echo "Running in CI stable mode - latest Positron + released Workbench without prompts..."
+  else
+    CI_INSTALL_FLAG="--ci"
+    echo "Running in CI mode - using latest versions without prompts..."
+  fi
   docker exec -it \
     -e GITHUB_TOKEN="$GITHUB_TOKEN" \
     -e DATABRICKS_URL_="${DATABRICKS_URL:-}" \
@@ -130,7 +142,7 @@ if [ "$CI_MODE" = true ]; then
     -e SNOWFLAKE_USERNAME_="${SNOWFLAKE_USERNAME:-}" \
     -e SNOWFLAKE_PASSWORD_="${SNOWFLAKE_PASSWORD:-}" \
     -e AZURE_SERVICE_PRINCIPAL_CLIENT_SECRET_="${AZURE_SERVICE_PRINCIPAL_CLIENT_SECRET:-}" \
-    test /bin/bash -c "/tmp/install-workbench.sh --ci ${CREDENTIALS:+--credentials=$CREDENTIALS}; exec /bin/bash"
+    test /bin/bash -c "/tmp/install-workbench.sh $CI_INSTALL_FLAG ${CREDENTIALS:+--credentials=$CREDENTIALS}; exec /bin/bash"
 else
   docker exec -it \
     -e GITHUB_TOKEN="$GITHUB_TOKEN" \

--- a/dockerfiles/wb-local/get-latest-wb-noble-url.sh
+++ b/dockerfiles/wb-local/get-latest-wb-noble-url.sh
@@ -1,17 +1,45 @@
 #!/bin/bash
 
 # Script to fetch the latest Ubuntu Noble Workbench URL from the Posit downloads endpoint
+#
+# Usage: ./get-latest-wb-noble-url.sh [arch]
+#   arch: amd64 (default) or arm64
+#
+# downloads.json only publishes the amd64 noble installer. The arm64 build is
+# released at the same path with "amd64" swapped for "arm64", so for arm64 we
+# fetch the amd64 URL and rewrite it.
 
 set -e
 
+ARCH="${1:-amd64}"
+case "$ARCH" in
+    amd64|x86_64) ARCH="amd64" ;;
+    arm64|aarch64) ARCH="arm64" ;;
+    *)
+        echo "❌ ERROR: Unsupported architecture '$ARCH' (expected amd64 or arm64)" >&2
+        exit 1
+        ;;
+esac
+
 JSON_ENDPOINT="https://posit.co/wp-content/uploads/downloads.json"
 
-# Fetch the JSON and extract the noble URL
+# Fetch the JSON and extract the noble URL (always amd64 in the feed)
 NOBLE_URL=$(curl -sL "$JSON_ENDPOINT" | jq -r '.rstudio.pro.stable.server.installer.noble.url')
 
 if [ -z "$NOBLE_URL" ] || [ "$NOBLE_URL" = "null" ]; then
     echo "❌ ERROR: Failed to fetch the latest Noble URL from $JSON_ENDPOINT" >&2
     exit 1
+fi
+
+# Rewrite the amd64 URL to arm64 when requested
+if [ "$ARCH" = "arm64" ]; then
+    NOBLE_URL=$(echo "$NOBLE_URL" | sed 's/amd64/arm64/g')
+
+    # Verify the arm64 artifact actually exists before returning it
+    if ! curl -sfI "$NOBLE_URL" >/dev/null 2>&1; then
+        echo "❌ ERROR: arm64 Workbench not available at $NOBLE_URL" >&2
+        exit 1
+    fi
 fi
 
 # Return the URL (useful when called from other scripts)

--- a/dockerfiles/wb-local/install-workbench.sh
+++ b/dockerfiles/wb-local/install-workbench.sh
@@ -218,10 +218,10 @@ fi
 # Now we can fetch the WB_URL if it wasn't provided
 if [ -z "${WB_URL}" ]; then
     if [ "$CI_STABLE_MODE" = true ]; then
-        echo "CI Stable Mode: Fetching latest released Workbench URL..."
+        echo "CI Stable Mode: Fetching latest released Workbench URL for ${ARCH_SUFFIX} architecture..."
         # Get the directory where this script is located
         SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-        WB_URL=$("${SCRIPT_DIR}/get-latest-wb-noble-url.sh")
+        WB_URL=$("${SCRIPT_DIR}/get-latest-wb-noble-url.sh" "${ARCH_SUFFIX}")
         if [ $? -ne 0 ] || [ -z "${WB_URL}" ]; then
             log_error "Failed to fetch released Workbench URL from get-latest-wb-noble-url.sh"
         fi


### PR DESCRIPTION
Previously, you couldn't locally pass --ci-stable to automatically get the last stable of workbench (ARM)

This adds that capability.