### PR TITLE
Fix issue with Azure in workbench tests

### DIFF
--- a/dockerfiles/wb-local/configure-datasources.sh
+++ b/dockerfiles/wb-local/configure-datasources.sh
@@ -31,7 +31,7 @@ client-id = ${DATABRICKS_CLIENT_ID_}
 EOF
         echo "  Created /etc/rstudio/databricks.conf for workspace: ${WORKSPACE_NAME}"
 
-        if ! grep -q "databricks-enabled=1" /etc/rstudio/rserver.conf 2>/dev/null; then
+        if ! grep -qE '^[[:space:]]*databricks-enabled=1' /etc/rstudio/rserver.conf 2>/dev/null; then
             echo "databricks-enabled=1" | sudo tee -a /etc/rstudio/rserver.conf > /dev/null
         fi
         echo "  Updated /etc/rstudio/rserver.conf with Databricks feature flag"
@@ -51,7 +51,7 @@ account = ${SNOWFLAKE_ACCOUNT_}
 EOF
         echo "  Created /etc/rstudio/snowflake.conf for account: ${SNOWFLAKE_ACCOUNT_}"
 
-        if ! grep -q "allow-refresh-snowflake-roles=1" /etc/rstudio/rserver.conf 2>/dev/null; then
+        if ! grep -qE '^[[:space:]]*allow-refresh-snowflake-roles=1' /etc/rstudio/rserver.conf 2>/dev/null; then
             echo "allow-refresh-snowflake-roles=1" | sudo tee -a /etc/rstudio/rserver.conf > /dev/null
         fi
         echo "  Updated /etc/rstudio/rserver.conf with Snowflake feature flag"
@@ -64,7 +64,7 @@ EOF
         fi
 
         # 2a. Append OpenID auth settings to rserver.conf
-        if ! grep -q "auth-openid=1" /etc/rstudio/rserver.conf 2>/dev/null; then
+        if ! grep -qE '^[[:space:]]*auth-openid=1' /etc/rstudio/rserver.conf 2>/dev/null; then
             sudo tee -a /etc/rstudio/rserver.conf > /dev/null <<EOF
 auth-openid=1
 auth-openid-issuer=https://login.microsoftonline.com/b0b52785-d0b5-4b72-a6d0-13ac07ebbbd7/v2.0

--- a/dockerfiles/wb-local/docker-compose.ubuntu24.yml
+++ b/dockerfiles/wb-local/docker-compose.ubuntu24.yml
@@ -38,6 +38,8 @@ services:
     environment:
       - E2E_POSTGRES_USER=${E2E_POSTGRES_USER:-testuser}
       - E2E_POSTGRES_PASSWORD=${E2E_POSTGRES_PASSWORD:-testpassword}
+      - POSTGRES_USER=${E2E_POSTGRES_USER:-testuser}
+      - POSTGRES_PASSWORD=${E2E_POSTGRES_PASSWORD:-testpassword}
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${E2E_POSTGRES_USER:-testuser} -d postgres"]
       interval: 5s
@@ -45,7 +47,7 @@ services:
       retries: 5
     restart: unless-stopped
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
   
   connect:
     image: rstudio/rstudio-connect-preview:dev-jammy-daily

--- a/dockerfiles/wb-local/install-workbench.sh
+++ b/dockerfiles/wb-local/install-workbench.sh
@@ -322,6 +322,21 @@ if ! sudo rstudio-server stop; then
     log_error "Failed to stop RStudio server"
 fi
 
+# rstudio-server stop can return before rserver has fully exited, and this
+# container has no systemd to wait on. Wait for rserver to actually exit so we
+# don't mutate its install dir while it's still running.
+echo "Waiting for rserver to stop..."
+for _ in $(seq 1 15); do
+    pgrep -x rserver >/dev/null 2>&1 || break
+    sleep 1
+done
+
+# Safety net: if rserver is still alive, signal it.
+if pgrep -x rserver >/dev/null 2>&1; then
+    echo "rserver still running - sending TERM..."
+    sudo pkill -x rserver 2>/dev/null || true
+fi
+
 cd /usr/lib/rstudio-server/bin/
 
 # Check if positron-server/bundled exists


### PR DESCRIPTION
Basically, the [configure-datasources.sh](https://github.com/posit-dev/qa-example-content/pull/155/changes#diff-9fa82a1bb3d42140d1b1c2a77a841890c544b48dce14a68ea5f0266127edad1b) script was not appending to reserver.conf because of a bad grep check
Also added a safety net when waiting for rserver to stop and a fix for the db setup of the local workbench infra