### PR TITLE
Fix container name conflicts between wb-local and arm-local

### DIFF
--- a/dockerfiles/arm-local/.env.example
+++ b/dockerfiles/arm-local/.env.example
@@ -3,3 +3,7 @@
 
 E2E_POSTGRES_USER=
 E2E_POSTGRES_PASSWORD=
+
+# Optional: prefix for container names (e.g. "arm-") — set this if you also run
+# wb-local at the same time to avoid container name conflicts. Leave unset in CI.
+# CONTAINER_PREFIX=arm-

--- a/dockerfiles/arm-local/README.md
+++ b/dockerfiles/arm-local/README.md
@@ -11,6 +11,9 @@ cp .env.example .env
 
 Fill in the values from 1Password under `Positron > E2E Postgres DB Connection info`.
 
+**Optional overrides** (add to `.env` if needed):
+* **CONTAINER_PREFIX**: Prefix for container names (e.g., `arm-`). Set this if you also run `wb-local` at the same time to avoid container name conflicts — containers become `arm-test`, `arm-postgres`, etc.
+
 ### 2. Create License File
 
 Create a `license.txt` file in this directory with the Positron Workbench License from 1Password (IDE/Workbench vault).

--- a/dockerfiles/arm-local/connect.sh
+++ b/dockerfiles/arm-local/connect.sh
@@ -52,8 +52,10 @@ if [ -f .env ]; then
   done < .env
 fi
 
+TEST_CONTAINER="${CONTAINER_PREFIX:-}test"
+
 # Check if the container is running
-if ! docker ps | grep -q "test"; then
+if ! docker ps | grep -q "$TEST_CONTAINER"; then
   echo "Error: test container is not running!"
   echo "Start with: npm run arm:start"
   exit 1
@@ -62,18 +64,18 @@ fi
 # Copy scripts to container (quietly)
 for script in setup-test-env.sh start-vnc.sh ssh-install.sh; do
   if [ -f "./$script" ]; then
-    docker cp "./$script" "test:/tmp/$script" >/dev/null 2>&1
-    docker exec test chmod +x "/tmp/$script" 2>/dev/null
+    docker cp "./$script" "$TEST_CONTAINER:/tmp/$script" >/dev/null 2>&1
+    docker exec "$TEST_CONTAINER" chmod +x "/tmp/$script" 2>/dev/null
   fi
 done
 
 # Connect to the container and run setup
 if [ "$CI_MODE" = true ]; then
   echo "Running in CI mode with branch: $CI_BRANCH"
-  docker exec -it test /bin/bash -c "/tmp/setup-test-env.sh '$CI_BRANCH' && exec /bin/bash -l"
+  docker exec -it "$TEST_CONTAINER" /bin/bash -c "/tmp/setup-test-env.sh '$CI_BRANCH' && exec /bin/bash -l"
 else
   # Interactive mode - show status and menu
-  docker exec -it test /bin/bash -c '
+  docker exec -it "$TEST_CONTAINER" /bin/bash -c '
     # Check setup status
     if [ -d "/__w/positron/positron/.git" ]; then
         BRANCH=$(cd /__w/positron/positron && git branch --show-current 2>/dev/null)

--- a/dockerfiles/arm-local/docker-compose.debian12.yml
+++ b/dockerfiles/arm-local/docker-compose.debian12.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   test:
     image: ghcr.io/posit-dev/positron-debian12-arm64:133
-    container_name: test
+    container_name: ${CONTAINER_PREFIX:-}test
     init: true
     ports:
       - "8080:8080"
@@ -25,7 +25,7 @@ services:
 
   postgres:
     image: ghcr.io/posit-dev/positron-postgres-arm64:143
-    container_name: postgres
+    container_name: ${CONTAINER_PREFIX:-}postgres
     ports:
       - "5432:5432"
     networks:

--- a/dockerfiles/arm-local/docker-compose.opensuse156.yml
+++ b/dockerfiles/arm-local/docker-compose.opensuse156.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   test:
     image: ghcr.io/posit-dev/positron-opensuse156-arm64:137
-    container_name: test
+    container_name: ${CONTAINER_PREFIX:-}test
     init: true
     ports:
       - "8080:8080"
@@ -25,7 +25,7 @@ services:
 
   postgres:
     image: ghcr.io/posit-dev/positron-postgres-arm64:143
-    container_name: postgres
+    container_name: ${CONTAINER_PREFIX:-}postgres
     ports:
       - "5432:5432"
     networks:

--- a/dockerfiles/arm-local/docker-compose.rocky8.yml
+++ b/dockerfiles/arm-local/docker-compose.rocky8.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   test:
     image: ghcr.io/posit-dev/positron-rocky8-arm64:129
-    container_name: test
+    container_name: ${CONTAINER_PREFIX:-}test
     init: true
     ports:
       - "8080:8080"
@@ -25,7 +25,7 @@ services:
 
   postgres:
     image: ghcr.io/posit-dev/positron-postgres-arm64:143
-    container_name: postgres
+    container_name: ${CONTAINER_PREFIX:-}postgres
     ports:
       - "5432:5432"
     networks:

--- a/dockerfiles/arm-local/docker-compose.sles156.yml
+++ b/dockerfiles/arm-local/docker-compose.sles156.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   test:
     image: ghcr.io/posit-dev/positron-sles156-arm64:135
-    container_name: test
+    container_name: ${CONTAINER_PREFIX:-}test
     init: true
     ports:
       - "8080:8080"
@@ -25,7 +25,7 @@ services:
 
   postgres:
     image: ghcr.io/posit-dev/positron-postgres-arm64:143
-    container_name: postgres
+    container_name: ${CONTAINER_PREFIX:-}postgres
     ports:
       - "5432:5432"
     networks:

--- a/dockerfiles/arm-local/docker-compose.ubuntu24.yml
+++ b/dockerfiles/arm-local/docker-compose.ubuntu24.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   test:
     image: ghcr.io/posit-dev/positron-ubuntu24-arm64:127
-    container_name: test
+    container_name: ${CONTAINER_PREFIX:-}test
     init: true
     ports:
       - "8080:8080"
@@ -27,7 +27,7 @@ services:
 
   postgres:
     image: ghcr.io/posit-dev/positron-postgres-arm64:143
-    container_name: postgres
+    container_name: ${CONTAINER_PREFIX:-}postgres
     ports:
       - "5432:5432"
     networks:

--- a/dockerfiles/arm-local/status.sh
+++ b/dockerfiles/arm-local/status.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 # status.sh - Show status of arm-local test environment
 
+# Load env so CONTAINER_PREFIX is available if set
+if [ -f .env ]; then
+  export $(grep -v '^#' .env | xargs) 2>/dev/null || true
+fi
+TEST_CONTAINER="${CONTAINER_PREFIX:-}test"
+POSTGRES_CONTAINER="${CONTAINER_PREFIX:-}postgres"
+
 echo "ARM-Local Test Environment Status"
 echo "=================================="
 echo ""
 
 # Check if containers are running
-if ! docker ps --format "{{.Names}}" | grep -qE "^(test|postgres)$"; then
+if ! docker ps --format "{{.Names}}" | grep -qE "^(${TEST_CONTAINER}|${POSTGRES_CONTAINER})$"; then
     echo "Containers: None running"
     echo ""
     echo "Start with: npm run arm:start"
@@ -15,20 +22,20 @@ fi
 
 # Show running containers
 echo "Containers:"
-docker ps --format "  {{.Names}}: {{.Status}}" | grep -E "test|postgres"
+docker ps --format "  {{.Names}}: {{.Status}}" | grep -E "${TEST_CONTAINER}|${POSTGRES_CONTAINER}"
 echo ""
 
 # If test container is running, get more info
-if docker ps --format "{{.Names}}" | grep -q "^test$"; then
+if docker ps --format "{{.Names}}" | grep -q "^${TEST_CONTAINER}$"; then
     echo "Test Environment:"
 
     # Check if repo exists and get branch
-    BRANCH=$(docker exec test bash -c 'cd /__w/positron/positron 2>/dev/null && git branch --show-current 2>/dev/null' 2>/dev/null)
+    BRANCH=$(docker exec "$TEST_CONTAINER" bash -c 'cd /__w/positron/positron 2>/dev/null && git branch --show-current 2>/dev/null' 2>/dev/null)
     if [ -n "$BRANCH" ]; then
         echo "  Branch: $BRANCH"
 
         # Get last commit
-        COMMIT=$(docker exec test bash -c 'cd /__w/positron/positron 2>/dev/null && git log -1 --format="%h %s" 2>/dev/null' 2>/dev/null)
+        COMMIT=$(docker exec "$TEST_CONTAINER" bash -c 'cd /__w/positron/positron 2>/dev/null && git log -1 --format="%h %s" 2>/dev/null' 2>/dev/null)
         if [ -n "$COMMIT" ]; then
             echo "  Commit: $COMMIT"
         fi
@@ -38,11 +45,11 @@ if docker ps --format "{{.Names}}" | grep -q "^test$"; then
     fi
 
     # Check if Xvfb is running
-    XVFB=$(docker exec test bash -c 'pgrep -x Xvfb >/dev/null && echo "running" || echo "not running"' 2>/dev/null)
+    XVFB=$(docker exec "$TEST_CONTAINER" bash -c 'pgrep -x Xvfb >/dev/null && echo "running" || echo "not running"' 2>/dev/null)
     echo "  Display (Xvfb): $XVFB"
 
     # Check if VNC is running
-    VNC=$(docker exec test bash -c 'pgrep -f "vnc|x0vnc" >/dev/null && echo "running on localhost:5900" || echo "not running"' 2>/dev/null)
+    VNC=$(docker exec "$TEST_CONTAINER" bash -c 'pgrep -f "vnc|x0vnc" >/dev/null && echo "running on localhost:5900" || echo "not running"' 2>/dev/null)
     echo "  VNC: $VNC"
 
     echo ""

--- a/dockerfiles/wb-local/.env.example
+++ b/dockerfiles/wb-local/.env.example
@@ -7,6 +7,10 @@ E2E_POSTGRES_PASSWORD=
 # Password for the 'user1' account in Workbench (choose your own)
 WB_PASSWORD=
 
+# Optional: prefix for container names (e.g. "wb-") — set this if you also run
+# arm-local at the same time to avoid container name conflicts. Leave unset in CI.
+# CONTAINER_PREFIX=wb-
+
 DATABRICKS_URL=
 DATABRICKS_CLIENT_ID=
 IDE_SERVICE_ACCOUNT_EMAIL=

--- a/dockerfiles/wb-local/README.md
+++ b/dockerfiles/wb-local/README.md
@@ -18,6 +18,7 @@ Fill in the values:
 **Optional overrides** (add to `.env` if needed):
 * **ARCH_SUFFIX**: Override auto-detected architecture (`arm64` or `amd64`)
 * **IMAGE_TAG**: Override the container image tag (e.g., `100` if the latest tag isn't available for your architecture)
+* **CONTAINER_PREFIX**: Prefix for container names (e.g., `wb-`). Set this if you also run `arm-local` at the same time to avoid container name conflicts — containers become `wb-test`, `wb-postgres`, etc.
 
 ### 2. Docker Login
 

--- a/dockerfiles/wb-local/connect.sh
+++ b/dockerfiles/wb-local/connect.sh
@@ -67,6 +67,8 @@ if [ -f .env ]; then
   export $(grep -v '^#' .env | xargs)
 fi
 
+TEST_CONTAINER="${CONTAINER_PREFIX:-}test"
+
 # GITHUB_TOKEN is always required
 if [ -z "$GITHUB_TOKEN" ]; then
   echo "Error: set GITHUB_TOKEN before running: GITHUB_TOKEN=your_token ./connect.sh"
@@ -74,7 +76,7 @@ if [ -z "$GITHUB_TOKEN" ]; then
 fi
 
 # Check if the container is running
-if ! docker ps | grep -q "test"; then
+if ! docker ps | grep -q "$TEST_CONTAINER"; then
   echo "Error: test container is not running!"
   echo "Start with: npm run wb:start"
   exit 1
@@ -83,24 +85,24 @@ fi
 # Copy scripts to container (quietly), stripping Windows line endings
 for script in install-workbench.sh positronDownload.sh get-latest-wb-noble-url.sh configure-datasources.sh; do
   if [ -f "./$script" ]; then
-    docker cp "./$script" "test:/tmp/$script" >/dev/null 2>&1
-    docker exec test sed -i 's/\r$//' "/tmp/$script" 2>/dev/null
-    docker exec test chmod +x "/tmp/$script" 2>/dev/null
+    docker cp "./$script" "$TEST_CONTAINER:/tmp/$script" >/dev/null 2>&1
+    docker exec "$TEST_CONTAINER" sed -i 's/\r$//' "/tmp/$script" 2>/dev/null
+    docker exec "$TEST_CONTAINER" chmod +x "/tmp/$script" 2>/dev/null
   fi
 done
 
 # Copy license file if present
 if [ -f "./workbench.lic" ]; then
-  docker cp "./workbench.lic" "test:/tmp/workbench.lic" >/dev/null 2>&1
+  docker cp "./workbench.lic" "$TEST_CONTAINER:/tmp/workbench.lic" >/dev/null 2>&1
 fi
 
 # Show current status
 echo ""
 echo "=== Status ==="
-WB_VERSION=$(docker exec test bash -c 'rstudio-server version 2>/dev/null | head -1 | awk "{print \$1}"' 2>/dev/null)
+WB_VERSION=$(docker exec "$TEST_CONTAINER" bash -c 'rstudio-server version 2>/dev/null | head -1 | awk "{print \$1}"' 2>/dev/null)
 if [ -n "$WB_VERSION" ] && [ "$WB_VERSION" != "" ]; then
     echo "Workbench: $WB_VERSION"
-    POSITRON_VERSION=$(docker exec test bash -c '
+    POSITRON_VERSION=$(docker exec "$TEST_CONTAINER" bash -c '
         for dir in /usr/lib/rstudio-server/bin/positron-server/new /usr/lib/rstudio-server/bin/positron-server; do
             if [ -f "$dir/product.json" ]; then
                 VER=$(grep "positronVersion" "$dir/product.json" 2>/dev/null | sed "s/.*\"positronVersion\": *\"\([^\"]*\)\".*/\1/")
@@ -142,7 +144,7 @@ if [ "$CI_MODE" = true ] || [ "$CI_STABLE_MODE" = true ]; then
     -e SNOWFLAKE_USERNAME_="${SNOWFLAKE_USERNAME:-}" \
     -e SNOWFLAKE_PASSWORD_="${SNOWFLAKE_PASSWORD:-}" \
     -e AZURE_SERVICE_PRINCIPAL_CLIENT_SECRET_="${AZURE_SERVICE_PRINCIPAL_CLIENT_SECRET:-}" \
-    test /bin/bash -c "/tmp/install-workbench.sh $CI_INSTALL_FLAG ${CREDENTIALS:+--credentials=$CREDENTIALS}; exec /bin/bash"
+    "$TEST_CONTAINER" /bin/bash -c "/tmp/install-workbench.sh $CI_INSTALL_FLAG ${CREDENTIALS:+--credentials=$CREDENTIALS}; exec /bin/bash"
 else
   docker exec -it \
     -e GITHUB_TOKEN="$GITHUB_TOKEN" \
@@ -159,7 +161,7 @@ else
     -e SNOWFLAKE_PASSWORD_="${SNOWFLAKE_PASSWORD:-}" \
     -e AZURE_SERVICE_PRINCIPAL_CLIENT_SECRET_="${AZURE_SERVICE_PRINCIPAL_CLIENT_SECRET:-}" \
     -e CREDENTIALS="${CREDENTIALS:-}" \
-    test /bin/bash -c '
+    "$TEST_CONTAINER" /bin/bash -c '
     /tmp/install-workbench.sh ${CREDENTIALS:+--credentials="$CREDENTIALS"}
 
     # Show quick reference before dropping to shell

--- a/dockerfiles/wb-local/docker-compose.ubuntu24.yml
+++ b/dockerfiles/wb-local/docker-compose.ubuntu24.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   test:
     image: ghcr.io/posit-dev/positron-ubuntu24-arm64:127
-    container_name: test
+    container_name: ${CONTAINER_PREFIX:-}test
     ports:
       - "8080:8080"
       - "5900:5900"
@@ -30,7 +30,7 @@ services:
 
   postgres:
     image: ghcr.io/posit-dev/positron-postgres-arm64:143
-    container_name: postgres
+    container_name: ${CONTAINER_PREFIX:-}postgres
     ports:
       - "5432:5432"
     networks:
@@ -52,7 +52,7 @@ services:
   connect:
     image: rstudio/rstudio-connect-preview:dev-jammy-daily
     platform: linux/amd64
-    container_name: connect
+    container_name: ${CONTAINER_PREFIX:-}connect
     networks:
       - mynetwork
     ports:

--- a/dockerfiles/wb-local/status.sh
+++ b/dockerfiles/wb-local/status.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
 # status.sh - Show status of wb-local test environment
 
+# Load env so CONTAINER_PREFIX is available if set
+if [ -f .env ]; then
+  export $(grep -v '^#' .env | xargs) 2>/dev/null || true
+fi
+TEST_CONTAINER="${CONTAINER_PREFIX:-}test"
+POSTGRES_CONTAINER="${CONTAINER_PREFIX:-}postgres"
+CONNECT_CONTAINER="${CONTAINER_PREFIX:-}connect"
+
 echo "WB-Local Test Environment Status"
 echo "================================="
 echo ""
 
 # Check if containers are running
-if ! docker ps --format "{{.Names}}" | grep -qE "^(test|postgres|connect)$"; then
+if ! docker ps --format "{{.Names}}" | grep -qE "^(${TEST_CONTAINER}|${POSTGRES_CONTAINER}|${CONNECT_CONTAINER})$"; then
     echo "Containers: None running"
     echo ""
     echo "Start with: npm run wb:start"
@@ -15,15 +23,15 @@ fi
 
 # Show running containers
 echo "Containers:"
-docker ps --format "  {{.Names}}: {{.Status}}" | grep -E "test|postgres|connect"
+docker ps --format "  {{.Names}}: {{.Status}}" | grep -E "${TEST_CONTAINER}|${POSTGRES_CONTAINER}|${CONNECT_CONTAINER}"
 echo ""
 
 # If test container is running, get more info
-if docker ps --format "{{.Names}}" | grep -q "^test$"; then
+if docker ps --format "{{.Names}}" | grep -q "^${TEST_CONTAINER}$"; then
     echo "Versions:"
 
     # Get Workbench version
-    WB_VERSION=$(docker exec test bash -c 'rstudio-server version 2>/dev/null | head -1 | awk "{print \$1}"' 2>/dev/null)
+    WB_VERSION=$(docker exec "$TEST_CONTAINER" bash -c 'rstudio-server version 2>/dev/null | head -1 | awk "{print \$1}"' 2>/dev/null)
     if [ -n "$WB_VERSION" ] && [ "$WB_VERSION" != "" ]; then
         echo "  Workbench: $WB_VERSION"
     else
@@ -32,7 +40,7 @@ if docker ps --format "{{.Names}}" | grep -q "^test$"; then
     fi
 
     # Get Positron version
-    POSITRON_VERSION=$(docker exec test bash -c '
+    POSITRON_VERSION=$(docker exec "$TEST_CONTAINER" bash -c '
         for dir in /usr/lib/rstudio-server/bin/positron-server/new /usr/lib/rstudio-server/bin/positron-server; do
             if [ -f "$dir/product.json" ]; then
                 VER=$(grep "positronVersion" "$dir/product.json" 2>/dev/null | sed "s/.*\"positronVersion\": *\"\([^\"]*\)\".*/\1/")
@@ -48,7 +56,7 @@ if docker ps --format "{{.Names}}" | grep -q "^test$"; then
     fi
 
     # Check RStudio server status
-    RS_STATUS=$(docker exec test bash -c 'rstudio-server status 2>/dev/null | head -1 || echo "unknown"' 2>/dev/null)
+    RS_STATUS=$(docker exec "$TEST_CONTAINER" bash -c 'rstudio-server status 2>/dev/null | head -1 || echo "unknown"' 2>/dev/null)
     echo "  Server:    $RS_STATUS"
 
     echo ""


### PR DESCRIPTION
### Summary
Both stacks hardcoded container names (`test`, `postgres`, `connect`), causing Docker to reject the second stack when both were running locally.
- All compose files now use `${CONTAINER_PREFIX:-}test` etc. — empty default keeps CI behavior identical
- `connect.sh` and `status.sh` in both stacks read `CONTAINER_PREFIX` from `.env` and use it in all `docker exec`/`docker cp`/`docker ps` calls
- Both `.env` files already updated with `wb-` and `arm-` prefixes respectively
- `.env.example` and READMEs updated so other devs know the option exists

### QA Notes
CI unaffected — `CONTAINER_PREFIX` is unset in CI, so container names remain `test`, `postgres`, `connect` as before.