### PR TITLE
Unpin htmltools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,4 +42,3 @@ SQLAlchemy
 psycopg2-binary
 ipykernel
 astropy
-htmltools<0.7


### PR DESCRIPTION
Completes https://github.com/posit-dev/positron/issues/13698

Unpins html tools  as it's now fixed in shiny. (see https://github.com/posit-dev/py-htmltools/issues/114)

