### PR TITLE
Fix largeParquet gitignore so git clean -fd stops wiping it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ workspaces/quarto_shiny/mini-app.html
 dockerfiles/all-tests/deps/pdol_rsa
 dockerfiles/all-tests/deps/.env
 **/.claude/*
+# Downloaded from S3 at e2e runtime (very-large-data-frame.test.ts); keep `git clean -fd` from wiping it mid-suite
+/data-files/largeParquet.parquet

--- a/workspaces/r_testing/.gitignore
+++ b/workspaces/r_testing/.gitignore
@@ -1,2 +1,1 @@
 .Rproj.user
-/data-files/largeParquet.parquet


### PR DESCRIPTION
I seemed to have messed this up previously...

PR #151 added `/data-files/largeParquet.parquet` to `workspaces/r_testing/.gitignore`, but the file is downloaded at e2e runtime to the repo-root `data-files/` directory, not under `workspaces/r_testing/`. A nested .gitignore only governs its own subtree, and the leading `/` anchored the rule to the nonexistent `workspaces/r_testing/data-files/`, so the rule never matched.

The untracked parquet therefore stayed un-ignored, and a concurrent e2e worker's `discardAllChanges()` teardown (`git reset --hard` + `git clean -fd`) wiped it mid-suite. The R "very large data frame" test then failed with `IOError: Failed to open ... largeParquet.parquet: No such file`.

Move the ignore to the root .gitignore (matching the real download path) and drop the stale r_testing entry.